### PR TITLE
Show file size and line count in file list

### DIFF
--- a/js/local.js
+++ b/js/local.js
@@ -2,7 +2,7 @@ import { displayDirectoryStructure, sortContents, getSelectedFiles, formatRepoCo
 import { extractZipContents } from './zip-utils.js';
 
 // Add at the top of the file with other imports
-let pathZipMap = {};
+window.pathZipMap = {};
 
 // Event listener for directory selection
 document.getElementById('directoryPicker').addEventListener('change', handleDirectorySelection);
@@ -59,7 +59,7 @@ async function handleZipSelection(event) {
 
         // Extract zip contents and update the global pathZipMap
         const { tree, gitignoreContent, pathZipMap: extractedPathZipMap } = await extractZipContents(file);
-        pathZipMap = extractedPathZipMap;  // Update the global variable
+        window.pathZipMap = extractedPathZipMap;  // Update the global variable
         
         // Filter and display the tree
         filterAndDisplayTree(tree, gitignoreContent);

--- a/js/utils.js
+++ b/js/utils.js
@@ -86,11 +86,20 @@ async function displayDirectoryStructure(tree) {
         appendIcon(li, 'file');
         li.appendChild(document.createTextNode(name));
 
-        // Add loading indicator while counting lines
-        const lineCountSpan = document.createElement('span');
-        lineCountSpan.className = 'text-gray-500 text-sm ml-2';
-        lineCountSpan.textContent = '(counting...)';
-        li.appendChild(lineCountSpan);
+        // Show file size and add loading indicator
+        const infoSpan = document.createElement('span');
+        infoSpan.className = 'text-gray-500 text-sm ml-2';
+        if (item.size && !isNaN(item.size)) {
+            const size = item.size > 1024 
+                ? item.size > 1024 * 1024 
+                    ? `${(item.size / (1024 * 1024)).toFixed(1)}MB` 
+                    : `${(item.size / 1024).toFixed(1)}KB`
+                : `${item.size}B`;
+            infoSpan.textContent = `(${size}, counting lines...)`;
+        } else {
+            infoSpan.textContent = '(counting...)';
+        }
+        li.appendChild(infoSpan);
 
         try {
             // Fetch file content to count lines
@@ -102,10 +111,20 @@ async function displayDirectoryStructure(tree) {
                 response = await fetch(item.url).then(r => r.text());
             }
             const lineCount = response.split('\n').length;
-            lineCountSpan.textContent = `(${lineCount} lines)`;
+            const sizeText = item.size ? item.size > 1024 
+                ? item.size > 1024 * 1024 
+                    ? `${(item.size / (1024 * 1024)).toFixed(1)}MB` 
+                    : `${(item.size / 1024).toFixed(1)}KB`
+                : `${item.size}B` : '';
+            infoSpan.textContent = sizeText ? `(${sizeText}, ${lineCount} lines)` : `(${lineCount} lines)`;
             item.lineCount = lineCount; // Store the line count for later use
         } catch (error) {
-            lineCountSpan.textContent = '(error counting lines)';
+            const sizeText = item.size ? item.size > 1024 
+                ? item.size > 1024 * 1024 
+                    ? `${(item.size / (1024 * 1024)).toFixed(1)}MB` 
+                    : `${(item.size / 1024).toFixed(1)}KB`
+                : `${item.size}B` : '';
+            infoSpan.textContent = sizeText ? `(${sizeText}, error counting lines)` : '(error counting lines)';
             console.error('Error counting lines:', error);
         }
     }


### PR DESCRIPTION
This PR adds the file size information in the file list view.\n\nNow you can see both the file size and number of lines (after loading) for each file in the list, which helps identify unusually large files and understand the structure of the repository better.\n\nClosing #1